### PR TITLE
feat: add pluggable connection limiter

### DIFF
--- a/ebin/ranch.app
+++ b/ebin/ranch.app
@@ -1,7 +1,7 @@
 {application, 'ranch', [
 	{description, "Socket acceptor pool for TCP protocols."},
 	{vsn, "2.2.0"},
-	{modules, ['ranch','ranch_acceptor','ranch_acceptors_sup','ranch_app','ranch_conns_sup','ranch_conns_sup_sup','ranch_crc32c','ranch_embedded_sup','ranch_listener_sup','ranch_protocol','ranch_proxy_header','ranch_server','ranch_server_proxy','ranch_ssl','ranch_sup','ranch_tcp','ranch_transport']},
+	{modules, ['ranch','ranch_acceptor','ranch_acceptors_sup','ranch_app','ranch_conns_limiter','ranch_conns_sup','ranch_conns_sup_sup','ranch_crc32c','ranch_embedded_sup','ranch_listener_sup','ranch_protocol','ranch_proxy_header','ranch_server','ranch_server_proxy','ranch_ssl','ranch_sup','ranch_tcp','ranch_transport']},
 	{registered, [ranch_sup,ranch_server]},
 	{applications, [kernel,stdlib,ssl]},
 	{optional_applications, []},

--- a/src/ranch.erl
+++ b/src/ranch.erl
@@ -137,6 +137,10 @@ validate_transport_opt(max_connections, infinity, _) ->
 	true;
 validate_transport_opt(max_connections, Value, _) ->
 	is_integer(Value) andalso Value >= 0;
+validate_transport_opt(limiter, {Module, _}, _) ->
+	is_atom(Module);
+validate_transport_opt(limiter, _, _) ->
+	false;
 validate_transport_opt(alarms, Alarms, _) ->
 	Alarms1 = compat_normalize_alarms_option(Alarms),
 	maps:fold(

--- a/src/ranch_acceptor.erl
+++ b/src/ranch_acceptor.erl
@@ -31,8 +31,8 @@ init(LSocket, Transport, Logger, ConnsSup) ->
 	loop(LSocket, Transport, Logger, ConnsSup, MonitorRef).
 
 -spec loop(inet:socket(), module(), module(), pid(), reference()) -> no_return().
-loop(LSocket, Transport, Logger, ConnsSup, MonitorRef) ->
-	_ = case Transport:accept(LSocket, infinity) of
+loop(LSocket0, Transport, Logger, ConnsSup, MonitorRef) ->
+	Ret = case accept(LSocket0, Transport, infinity) of
 		{ok, CSocket} ->
 			case Transport:controlling_process(CSocket, ConnsSup) of
 				ok ->
@@ -50,16 +50,49 @@ loop(LSocket, Transport, Logger, ConnsSup, MonitorRef) ->
 			ranch:log(warning,
 				"Ranch acceptor reducing accept rate: out of file descriptors~n",
 				[], Logger),
-			receive after 100 -> ok end;
+			receive after 100 -> loop end;
 		%% Exit if the listening socket got closed.
 		{error, closed} ->
 			exit(closed);
 		%% Continue otherwise.
 		{error, _} ->
-			ok
+			loop
+	end,
+	LSocket = case Ret of
+		%% Accept succeeded and connection process started.
+		ok -> depenalize(LSocket0);
+		%% Accept succeeded but connsup returned penalty.
+		{penalty, Penalty} -> penalize(Penalty, LSocket0);
+		%% Otherwise, accept errors or active penalty.
+		loop -> LSocket0
 	end,
 	flush(Logger),
 	?MODULE:loop(LSocket, Transport, Logger, ConnsSup, MonitorRef).
+
+accept({close_until, Deadline, LSocket}, Transport, Timeout) ->
+	case Transport:accept(LSocket, Timeout) of
+		{ok, CSocket} ->
+			case erlang:monotonic_time(millisecond) of
+				T when T < Deadline ->
+					Transport:close(CSocket),
+					{error, penalty};
+				_ ->
+					{ok, CSocket}
+			end;
+		Error ->
+			Error
+	end;
+accept(LSocket, Transport, Timeout) ->
+	Transport:accept(LSocket, Timeout).
+
+penalize({close_connections_for, Milliseconds}, LSocket) ->
+	Deadline = erlang:monotonic_time(millisecond) + Milliseconds,
+	{close_until, Deadline, LSocket}.
+
+depenalize({close_until, _, LSocket}) ->
+	LSocket;
+depenalize(LSocket) ->
+	LSocket.
 
 flush(Logger) ->
 	receive Msg ->

--- a/src/ranch_conns_limiter.erl
+++ b/src/ranch_conns_limiter.erl
@@ -1,0 +1,63 @@
+%% Copyright (c) 2025 EMQ Technologies Co., Ltd.
+%%
+%% Permission to use, copy, modify, and/or distribute this software for any
+%% purpose with or without fee is hereby granted, provided that the above
+%% copyright notice and this permission notice appear in all copies.
+%%
+%% THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+%% WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+%% MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+%% ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+%% WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+%% ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+%% OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+-module(ranch_conns_limiter).
+
+-export([create/2]).
+-export([allow/2]).
+-export([accepted/2, retired/2]).
+
+-export_type([limiter/0, penalty/0]).
+
+-type limiter() :: {module(), _State}.
+
+-type penalty() ::
+    close_connection
+    | {close_connections_for, _Milliseconds :: non_neg_integer()}.
+
+%% Create new limiter.
+-callback create(_Options) -> _State.
+
+%% Ask the limiter if connection could be accepted.
+-callback allow(_Socket, State) -> {ok | penalty(), State}.
+
+%% Notify limited that a connection was accepted.
+-callback accepted(pid(), State) -> State.
+
+%% Notify limited that a previously accepted connection is gone.
+-callback retired(pid(), State) -> State.
+
+%%
+
+-spec create(module(), _Options) -> limiter().
+create(Module, Options) ->
+    {Module, Module:create(Options)}.
+
+%% Ask the limiter if connection could be accepted.
+-spec allow(_Socket, limiter()) -> {ok | penalty(), limiter()}.
+allow(Socket, {Module, State}) ->
+    {Result, NState} = Module:allow(Socket, State),
+    {Result, {Module, NState}}.
+
+%% Notify limited that a connection was accepted.
+-spec accepted(pid(), limiter()) -> limiter().
+accepted(Pid, {Module, State}) ->
+    NState = Module:accepted(Pid, State),
+    {Module, NState}.
+
+%% Notify limited that a previously accepted connection is gone.
+-spec retired(pid(), limiter()) -> limiter().
+retired(Pid, {Module, State}) ->
+    NState = Module:retired(Pid, State),
+    {Module, NState}.

--- a/src/ranch_conns_sup.erl
+++ b/src/ranch_conns_sup.erl
@@ -43,6 +43,7 @@
 	opts :: any(),
 	handshake_timeout :: timeout(),
 	max_conns = undefined :: ranch:max_conns(),
+	limiter_opts = undefined :: {module(), _Options} | undefined,
 	stats_counters_ref :: counters:counters_ref(),
 	alarms = #{} :: #{term() => {map(), undefined | reference()}},
 	logger = undefined :: module()
@@ -114,7 +115,8 @@ init(Parent, Ref, Id, Transport, TransOpts, Protocol, Logger) ->
 	ConnType = maps:get(connection_type, TransOpts, worker),
 	Shutdown = maps:get(shutdown, TransOpts, 5000),
 	HandshakeTimeout = maps:get(handshake_timeout, TransOpts, 5000),
-	Limiter = limiter_init(maps:get(limiter, TransOpts, undefined)),
+	LimiterOpts = maps:get(limiter, TransOpts, undefined),
+	Limiter = limiter_init(LimiterOpts),
 	ProtoOpts = ranch_server:get_protocol_options(Ref),
 	StatsCounters = ranch_server:get_stats_counters(Ref),
 	ok = proc_lib:init_ack(Parent, {ok, self()}),
@@ -123,6 +125,7 @@ init(Parent, Ref, Id, Transport, TransOpts, Protocol, Logger) ->
 		opts=ProtoOpts, stats_counters_ref=StatsCounters,
 		handshake_timeout=HandshakeTimeout,
 		max_conns=MaxConns, alarms=Alarms,
+		limiter_opts=LimiterOpts,
 		logger=Logger}, 0, 0, Limiter, []).
 
 loop(State=#state{parent=Parent, ref=Ref, id=Id, conn_type=ConnType,
@@ -302,6 +305,19 @@ limiter_init(undefined) ->
 limiter_init({Module, Options}) ->
 	ranch_conns_limiter:create(Module, Options).
 
+limiter_reinit(undefined) ->
+	undefined;
+limiter_reinit(ModOpts) ->
+	Limiter = limiter_init(ModOpts),
+	lists:foldl(
+		fun ({Pid, Type}, LimiterAcc) when Type =:= active orelse Type =:= removed ->
+				limiter_accepted(Pid, LimiterAcc);
+			(_, LimiterAcc) ->
+				LimiterAcc
+		end,
+		Limiter,
+		erlang:get()).
+
 limiter_allow(_Socket, undefined) ->
 	{ok, undefined};
 limiter_allow(Socket, Limiter) ->
@@ -367,11 +383,18 @@ get_alarms(#{alarms := Alarms}) when is_map(Alarms) ->
 get_alarms(_) ->
 	#{}.
 
-set_transport_options(State=#state{max_conns=MaxConns0},
+set_transport_options(State=#state{max_conns=MaxConns0, limiter_opts=LimiterOpts0},
 		CurConns, NbChildren, Limiter, Sleepers0, TransOpts) ->
 	MaxConns1 = maps:get(max_connections, TransOpts, 1024),
 	HandshakeTimeout = maps:get(handshake_timeout, TransOpts, 5000),
 	Shutdown = maps:get(shutdown, TransOpts, 5000),
+	Limiter1 = case maps:get(limiter, TransOpts, undefined) of
+			LimiterOpts0 ->
+				Limiter;
+			LimiterOpts ->
+				%% Limiter needs to be re-initialized.
+				limiter_reinit(LimiterOpts)
+		end,
 	Sleepers1 = case MaxConns1 > MaxConns0 of
 		true ->
 			_ = [To ! self() || To <- Sleepers0],
@@ -381,7 +404,7 @@ set_transport_options(State=#state{max_conns=MaxConns0},
 	end,
 	State1=set_alarm_option(State, TransOpts, CurConns),
 	loop(State1#state{max_conns=MaxConns1, handshake_timeout=HandshakeTimeout, shutdown=Shutdown},
-		CurConns, NbChildren, Limiter, Sleepers1).
+		CurConns, NbChildren, Limiter1, Sleepers1).
 
 set_alarm_option(State=#state{ref=Ref, alarms=OldAlarms}, TransOpts, CurConns) ->
 	NewAlarms0 = get_alarms(TransOpts),

--- a/src/ranch_conns_sup.erl
+++ b/src/ranch_conns_sup.erl
@@ -77,6 +77,8 @@ start_protocol(SupPid, MonitorRef, Socket) ->
 	receive
 		SupPid ->
 			ok;
+		{SupPid, Reply} ->
+			Reply;
 		{'DOWN', MonitorRef, process, SupPid, Reason} ->
 			error(Reason)
 	end.
@@ -112,6 +114,7 @@ init(Parent, Ref, Id, Transport, TransOpts, Protocol, Logger) ->
 	ConnType = maps:get(connection_type, TransOpts, worker),
 	Shutdown = maps:get(shutdown, TransOpts, 5000),
 	HandshakeTimeout = maps:get(handshake_timeout, TransOpts, 5000),
+	Limiter = limiter_init(maps:get(limiter, TransOpts, undefined)),
 	ProtoOpts = ranch_server:get_protocol_options(Ref),
 	StatsCounters = ranch_server:get_stats_counters(Ref),
 	ok = proc_lib:init_ack(Parent, {ok, self()}),
@@ -120,20 +123,29 @@ init(Parent, Ref, Id, Transport, TransOpts, Protocol, Logger) ->
 		opts=ProtoOpts, stats_counters_ref=StatsCounters,
 		handshake_timeout=HandshakeTimeout,
 		max_conns=MaxConns, alarms=Alarms,
-		logger=Logger}, 0, 0, []).
+		logger=Logger}, 0, 0, Limiter, []).
 
 loop(State=#state{parent=Parent, ref=Ref, id=Id, conn_type=ConnType,
 		transport=Transport, protocol=Protocol, opts=Opts, stats_counters_ref=StatsCounters,
-		alarms=Alarms, max_conns=MaxConns, logger=Logger}, CurConns, NbChildren, Sleepers) ->
+		alarms=Alarms, max_conns=MaxConns, logger=Logger},
+		CurConns, NbChildren, Limiter, Sleepers) ->
 	receive
 		{?MODULE, start_protocol, To, Socket} ->
-			try Protocol:start_link(Ref, Transport, Opts) of
+			{LimitRet, Limiter1} = limiter_allow(Socket, Limiter),
+			try LimitRet == ok andalso Protocol:start_link(Ref, Transport, Opts) of
 				{ok, Pid} ->
 					inc_accept(StatsCounters, Id, 1),
-					handshake(State, CurConns, NbChildren, Sleepers, To, Socket, Pid, Pid);
+					Limiter2 = limiter_accepted(Pid, Limiter1),
+					handshake(State, CurConns, NbChildren, Limiter2, Sleepers,
+						To, Socket, Pid, Pid);
 				{ok, SupPid, ProtocolPid} when ConnType =:= supervisor ->
 					inc_accept(StatsCounters, Id, 1),
-					handshake(State, CurConns, NbChildren, Sleepers, To, Socket, SupPid, ProtocolPid);
+					Limiter2 = limiter_accepted(SupPid, Limiter1),
+					handshake(State, CurConns, NbChildren, Limiter2, Sleepers,
+						To, Socket, SupPid, ProtocolPid);
+				false ->
+					penalize(State, LimitRet, Socket, To),
+					loop(State, CurConns, NbChildren, Limiter1, Sleepers);
 				Ret ->
 					To ! self(),
 					ranch:log(error,
@@ -141,7 +153,7 @@ loop(State=#state{parent=Parent, ref=Ref, id=Id, conn_type=ConnType,
 						"~p:start_link/3 returned: ~0p~n",
 						[Ref, Protocol, Ret], Logger),
 					Transport:close(Socket),
-					loop(State, CurConns, NbChildren, Sleepers)
+					loop(State, CurConns, NbChildren, Limiter1, Sleepers)
 			catch Class:Reason ->
 				To ! self(),
 				ranch:log(error,
@@ -149,48 +161,49 @@ loop(State=#state{parent=Parent, ref=Ref, id=Id, conn_type=ConnType,
 					"~p:start_link/3 crashed with reason: ~p:~0p~n",
 					[Ref, Protocol, Class, Reason], Logger),
 				Transport:close(Socket),
-				loop(State, CurConns, NbChildren, Sleepers)
+				loop(State, CurConns, NbChildren, Limiter1, Sleepers)
 			end;
 		{?MODULE, active_connections, To, Tag} ->
 			To ! {Tag, CurConns},
-			loop(State, CurConns, NbChildren, Sleepers);
+			loop(State, CurConns, NbChildren, Limiter, Sleepers);
 		%% Remove a connection from the count of connections.
 		{remove_connection, Ref, Pid} ->
 			case put(Pid, removed) of
 				active when Sleepers =:= [] ->
-					loop(State, CurConns - 1, NbChildren, Sleepers);
+					loop(State, CurConns - 1, NbChildren, Limiter, Sleepers);
 				active ->
 					[To|Sleepers2] = Sleepers,
 					To ! self(),
-					loop(State, CurConns - 1, NbChildren, Sleepers2);
+					loop(State, CurConns - 1, NbChildren, Limiter, Sleepers2);
 				removed ->
-					loop(State, CurConns, NbChildren, Sleepers);
+					loop(State, CurConns, NbChildren, Limiter, Sleepers);
 				undefined ->
 					_ = erase(Pid),
-					loop(State, CurConns, NbChildren, Sleepers)
+					loop(State, CurConns, NbChildren, Limiter, Sleepers)
 			end;
 		%% Upgrade the max number of connections allowed concurrently.
 		%% We resume all sleeping acceptors if this number increases.
 		{set_max_conns, MaxConns2} when MaxConns2 > MaxConns ->
 			_ = [To ! self() || To <- Sleepers],
 			loop(State#state{max_conns=MaxConns2},
-				CurConns, NbChildren, []);
+				CurConns, NbChildren, Limiter, []);
 		{set_max_conns, MaxConns2} ->
 			loop(State#state{max_conns=MaxConns2},
-				CurConns, NbChildren, Sleepers);
+				CurConns, NbChildren, Limiter, Sleepers);
 		%% Upgrade the transport options.
 		{set_transport_options, TransOpts} ->
-			set_transport_options(State, CurConns, NbChildren, Sleepers, TransOpts);
+			set_transport_options(State, CurConns, NbChildren, Limiter, Sleepers, TransOpts);
 		%% Upgrade the protocol options.
 		{set_protocol_options, Opts2} ->
 			loop(State#state{opts=Opts2},
-				CurConns, NbChildren, Sleepers);
+				CurConns, NbChildren, Limiter, Sleepers);
 		{timeout, _, {activate_alarm, AlarmName}} when is_map_key(AlarmName, Alarms) ->
 			{AlarmOpts, _} = maps:get(AlarmName, Alarms),
 			NewAlarm = trigger_alarm(Ref, AlarmName, {AlarmOpts, undefined}, CurConns),
-			loop(State#state{alarms=Alarms#{AlarmName => NewAlarm}}, CurConns, NbChildren, Sleepers);
+			loop(State#state{alarms=Alarms#{AlarmName => NewAlarm}},
+				CurConns, NbChildren, Limiter, Sleepers);
 		{timeout, _, {activate_alarm, _}} ->
-			loop(State, CurConns, NbChildren, Sleepers);
+			loop(State, CurConns, NbChildren, Limiter, Sleepers);
 		{'EXIT', Parent, Reason} ->
 			terminate(State, Reason, NbChildren);
 		{'EXIT', Pid, Reason} when Sleepers =:= [] ->
@@ -198,13 +211,15 @@ loop(State=#state{parent=Parent, ref=Ref, id=Id, conn_type=ConnType,
 				active ->
 					inc_terminate(StatsCounters, Id, 1),
 					report_error(Logger, Ref, Protocol, Pid, Reason),
-					loop(State, CurConns - 1, NbChildren - 1, Sleepers);
+					Limiter1 = limiter_retired(Pid, Limiter),
+					loop(State, CurConns - 1, NbChildren - 1, Limiter1, Sleepers);
 				removed ->
 					inc_terminate(StatsCounters, Id, 1),
 					report_error(Logger, Ref, Protocol, Pid, Reason),
-					loop(State, CurConns, NbChildren - 1, Sleepers);
+					Limiter1 = limiter_retired(Pid, Limiter),
+					loop(State, CurConns, NbChildren - 1, Limiter1, Sleepers);
 				undefined ->
-					loop(State, CurConns, NbChildren, Sleepers)
+					loop(State, CurConns, NbChildren, Limiter, Sleepers)
 			end;
 		%% Resume a sleeping acceptor if needed.
 		{'EXIT', Pid, Reason} ->
@@ -212,30 +227,33 @@ loop(State=#state{parent=Parent, ref=Ref, id=Id, conn_type=ConnType,
 				active when CurConns > MaxConns ->
 					inc_terminate(StatsCounters, Id, 1),
 					report_error(Logger, Ref, Protocol, Pid, Reason),
-					loop(State, CurConns - 1, NbChildren - 1, Sleepers);
+					Limiter1 = limiter_retired(Pid, Limiter),
+					loop(State, CurConns - 1, NbChildren - 1, Limiter1, Sleepers);
 				active ->
 					inc_terminate(StatsCounters, Id, 1),
 					report_error(Logger, Ref, Protocol, Pid, Reason),
 					[To|Sleepers2] = Sleepers,
 					To ! self(),
-					loop(State, CurConns - 1, NbChildren - 1, Sleepers2);
+					Limiter1 = limiter_retired(Pid, Limiter),
+					loop(State, CurConns - 1, NbChildren - 1, Limiter1, Sleepers2);
 				removed ->
 					inc_terminate(StatsCounters, Id, 1),
 					report_error(Logger, Ref, Protocol, Pid, Reason),
-					loop(State, CurConns, NbChildren - 1, Sleepers);
+					Limiter1 = limiter_retired(Pid, Limiter),
+					loop(State, CurConns, NbChildren - 1, Limiter1, Sleepers);
 				undefined ->
-					loop(State, CurConns, NbChildren, Sleepers)
+					loop(State, CurConns, NbChildren, Limiter, Sleepers)
 			end;
 		{system, From, Request} ->
 			sys:handle_system_msg(Request, From, Parent, ?MODULE, [],
-				{State, CurConns, NbChildren, Sleepers});
+				{State, CurConns, NbChildren, Limiter, Sleepers});
 		%% Calls from the supervisor module.
 		{'$gen_call', {To, Tag}, which_children} ->
 			Children = [{Protocol, Pid, ConnType, [Protocol]}
 				|| {Pid, Type} <- get(),
 				Type =:= active orelse Type =:= removed],
 			To ! {Tag, Children},
-			loop(State, CurConns, NbChildren, Sleepers);
+			loop(State, CurConns, NbChildren, Limiter, Sleepers);
 		{'$gen_call', {To, Tag}, count_children} ->
 			Counts = case ConnType of
 				worker -> [{supervisors, 0}, {workers, NbChildren}];
@@ -243,19 +261,20 @@ loop(State=#state{parent=Parent, ref=Ref, id=Id, conn_type=ConnType,
 			end,
 			Counts2 = [{specs, 1}, {active, NbChildren}|Counts],
 			To ! {Tag, Counts2},
-			loop(State, CurConns, NbChildren, Sleepers);
+			loop(State, CurConns, NbChildren, Limiter, Sleepers);
 		{'$gen_call', {To, Tag}, _} ->
 			To ! {Tag, {error, ?MODULE}},
-			loop(State, CurConns, NbChildren, Sleepers);
+			loop(State, CurConns, NbChildren, Limiter, Sleepers);
 		Msg ->
 			ranch:log(error,
 				"Ranch listener ~p received unexpected message ~p~n",
 				[Ref, Msg], Logger),
-			loop(State, CurConns, NbChildren, Sleepers)
+			loop(State, CurConns, NbChildren, Limiter, Sleepers)
 	end.
 
 handshake(State=#state{ref=Ref, transport=Transport, handshake_timeout=HandshakeTimeout,
-		max_conns=MaxConns, alarms=Alarms0}, CurConns, NbChildren, Sleepers, To, Socket, SupPid, ProtocolPid) ->
+		max_conns=MaxConns, alarms=Alarms0}, CurConns, NbChildren, Limiter, Sleepers,
+		To, Socket, SupPid, ProtocolPid) ->
 	case Transport:controlling_process(Socket, ProtocolPid) of
 		ok ->
 			ProtocolPid ! {handshake, Ref, Transport, Socket, HandshakeTimeout},
@@ -268,15 +287,42 @@ handshake(State=#state{ref=Ref, transport=Transport, handshake_timeout=Handshake
 					[To|Sleepers]
 			end,
 			Alarms1 = trigger_alarms(Ref, Alarms0, CurConns2),
-			loop(State#state{alarms=Alarms1}, CurConns2, NbChildren + 1, Sleepers2);
+			loop(State#state{alarms=Alarms1}, CurConns2, NbChildren + 1, Limiter, Sleepers2);
 		{error, _} ->
 			Transport:close(Socket),
 			%% Only kill the supervised pid, because the connection's pid,
 			%% when different, is supposed to be sitting under it and linked.
 			exit(SupPid, kill),
 			To ! self(),
-			loop(State, CurConns, NbChildren, Sleepers)
+			loop(State, CurConns, NbChildren, Limiter, Sleepers)
 	end.
+
+limiter_init(undefined) ->
+	undefined;
+limiter_init({Module, Options}) ->
+	ranch_conns_limiter:create(Module, Options).
+
+limiter_allow(_Socket, undefined) ->
+	{ok, undefined};
+limiter_allow(Socket, Limiter) ->
+	ranch_conns_limiter:allow(Socket, Limiter).
+
+limiter_accepted(_Pid, undefined) ->
+	undefined;
+limiter_accepted(Pid, Limiter) ->
+	ranch_conns_limiter:accepted(Pid, Limiter).
+
+limiter_retired(_Pid, undefined) ->
+	undefined;
+limiter_retired(Pid, Limiter) ->
+	ranch_conns_limiter:retired(Pid, Limiter).
+
+penalize(#state{transport=Transport}, close_connection, Socket, To) ->
+	Transport:close(Socket),
+	To ! self();
+penalize(#state{transport=Transport}, Penalty, Socket, To) ->
+	Transport:close(Socket),
+	To ! {self(), {penalty, Penalty}}.
 
 trigger_alarms(Ref, Alarms, CurConns) ->
 	maps:map(
@@ -321,7 +367,8 @@ get_alarms(#{alarms := Alarms}) when is_map(Alarms) ->
 get_alarms(_) ->
 	#{}.
 
-set_transport_options(State=#state{max_conns=MaxConns0}, CurConns, NbChildren, Sleepers0, TransOpts) ->
+set_transport_options(State=#state{max_conns=MaxConns0},
+		CurConns, NbChildren, Limiter, Sleepers0, TransOpts) ->
 	MaxConns1 = maps:get(max_connections, TransOpts, 1024),
 	HandshakeTimeout = maps:get(handshake_timeout, TransOpts, 5000),
 	Shutdown = maps:get(shutdown, TransOpts, 5000),
@@ -334,7 +381,7 @@ set_transport_options(State=#state{max_conns=MaxConns0}, CurConns, NbChildren, S
 	end,
 	State1=set_alarm_option(State, TransOpts, CurConns),
 	loop(State1#state{max_conns=MaxConns1, handshake_timeout=HandshakeTimeout, shutdown=Shutdown},
-		CurConns, NbChildren, Sleepers1).
+		CurConns, NbChildren, Limiter, Sleepers1).
 
 set_alarm_option(State=#state{ref=Ref, alarms=OldAlarms}, TransOpts, CurConns) ->
 	NewAlarms0 = get_alarms(TransOpts),
@@ -464,11 +511,11 @@ wait_children(NbChildren) ->
 	end.
 
 -spec system_continue(_, _, any()) -> no_return().
-system_continue(_, _, {State, CurConns, NbChildren, Sleepers}) ->
-	loop(State, CurConns, NbChildren, Sleepers).
+system_continue(_, _, {State, CurConns, NbChildren, Limiter, Sleepers}) ->
+	loop(State, CurConns, NbChildren, Limiter, Sleepers).
 
 -spec system_terminate(any(), _, _, _) -> no_return().
-system_terminate(Reason, _, _, {State, _, NbChildren, _}) ->
+system_terminate(Reason, _, _, {State, _, NbChildren, _, _}) ->
 	terminate(State, Reason, NbChildren).
 
 -spec system_code_change(any(), _, _, _) -> {ok, any()}.

--- a/src/ranch_conns_sup.erl
+++ b/src/ranch_conns_sup.erl
@@ -519,6 +519,8 @@ system_terminate(Reason, _, _, {State, _, NbChildren, _, _}) ->
 	terminate(State, Reason, NbChildren).
 
 -spec system_code_change(any(), _, _, _) -> {ok, any()}.
+system_code_change({State, CurConns, NbChildren, Sleepers}, _, _, _) ->
+	{ok, {State, CurConns, NbChildren, undefined, Sleepers}};
 system_code_change(Misc, _, _, _) ->
 	{ok, Misc}.
 

--- a/test/acceptor_SUITE.erl
+++ b/test/acceptor_SUITE.erl
@@ -481,7 +481,7 @@ misc_set_transport_options(_) ->
 		num_acceptors => 2, shutdown => 1001, socket_opts => [{send_timeout, 5002}]}),
 	ConnsSups = [ConnsSup || {_, ConnsSup} <- ranch_server:get_connections_sups(Name)],
 	_ = [begin
-		{State, _, _, _} = sys:get_state(ConnsSup),
+		{State, _, _, _, _} = sys:get_state(ConnsSup),
 		20 = element(11, State),
 		5001 = element(10, State),
 		1001 = element(6, State)

--- a/test/acceptor_SUITE.erl
+++ b/test/acceptor_SUITE.erl
@@ -44,6 +44,7 @@ groups() ->
 		tcp_max_connections_infinity,
 		tcp_remove_connections,
 		tcp_remove_connections_acceptor_wakeup,
+		tcp_limiter_penalty,
 		tcp_set_max_connections,
 		tcp_set_max_connections_clean,
 		tcp_getopts_capability,
@@ -64,6 +65,7 @@ groups() ->
 		tcp_max_connections_infinity,
 		tcp_remove_connections,
 		tcp_remove_connections_acceptor_wakeup,
+		tcp_limiter_penalty,
 		tcp_set_max_connections,
 		tcp_set_max_connections_clean,
 		tcp_getopts_capability,
@@ -1507,6 +1509,49 @@ tcp_remove_connections_acceptor_wakeup(Config) ->
 	true = maps:get(all_connections, ranch:info(Name)) >= 2,
 	ok = gen_tcp:send(Socket1, <<"bye">>),
 	ok = gen_tcp:send(Socket2, <<"bye">>),
+	ok = ranch:stop_listener(Name).
+
+tcp_limiter_penalty(Config) ->
+	doc("Ensure that acceptor reacts to connection limiter."),
+	Name = name(),
+	SockOpts = config(socket_opts, Config),
+	Limiter = {counting_limiter,
+		#{every => 2, penalty => {close_connections_for, 1000}, report_to => self()}},
+	{ok, _} = ranch:start_listener(Name,
+		ranch_tcp, #{num_acceptors => 1, limiter => Limiter, socket_opts => SockOpts},
+		echo_protocol, []),
+	Port = ranch:get_port(Name),
+	ConnectOptions = [binary, {active, false}],
+	Localhost = "localhost",
+	%% First connection is allowed:
+	{ok, Socket1} = gen_tcp:connect(Localhost, Port, ConnectOptions),
+	{error, timeout} = gen_tcp:recv(Socket1, 0, 100),
+	%% Second connection is disallowed, and acceptor is penalized for a second:
+	{ok, Socket2} = gen_tcp:connect(Localhost, Port, ConnectOptions),
+	{error, closed} = gen_tcp:recv(Socket2, 0, 100),
+	{ok, Socket3} = gen_tcp:connect(Localhost, Port, ConnectOptions),
+	{error, closed} = gen_tcp:recv(Socket3, 0, 100),
+	%% Wait for it to cooldown:
+	receive after 1000 -> ok end,
+	%% Third connection is allowed:
+	{ok, Socket4} = gen_tcp:connect(Localhost, Port, ConnectOptions),
+	{error, timeout} = gen_tcp:recv(Socket4, 0, 100),
+	%% Likewise for fourth connection:
+	{ok, Socket5} = gen_tcp:connect(Localhost, Port, ConnectOptions),
+	{error, closed} = gen_tcp:recv(Socket5, 0, 100),
+	{ok, Socket6} = gen_tcp:connect(Localhost, Port, ConnectOptions),
+	{error, closed} = gen_tcp:recv(Socket6, 0, 100),
+	ok = gen_tcp:close(Socket1),
+	ok = gen_tcp:close(Socket4),
+	%% Verify limiter was notified of connection and process events:
+	receive {allow, [_Socket1], ok} -> ok after 100 -> error(timeout) end,
+	receive {accepted, [_Pid1]} -> ok after 100 -> error(timeout) end,
+	receive {allow, [_Socket2], {close_connections_for, _}} -> ok after 100 -> error(timeout) end,
+	receive {allow, [_Socket4], ok} -> ok after 100 -> error(timeout) end,
+	receive {accepted, [_Pid4]} -> ok after 100 -> error(timeout) end,
+	receive {allow, [_Socket5], {close_connections_for, _}} -> ok after 100 -> error(timeout) end,
+	receive {retired, [_]} -> ok after 100 -> error(timeout) end,
+	receive {retired, [_]} -> ok after 100 -> error(timeout) end,
 	ok = ranch:stop_listener(Name).
 
 tcp_set_max_connections(Config) ->

--- a/test/acceptor_SUITE.erl
+++ b/test/acceptor_SUITE.erl
@@ -45,6 +45,7 @@ groups() ->
 		tcp_remove_connections,
 		tcp_remove_connections_acceptor_wakeup,
 		tcp_limiter_penalty,
+		tcp_limiter_set_transport_options,
 		tcp_set_max_connections,
 		tcp_set_max_connections_clean,
 		tcp_getopts_capability,
@@ -66,6 +67,7 @@ groups() ->
 		tcp_remove_connections,
 		tcp_remove_connections_acceptor_wakeup,
 		tcp_limiter_penalty,
+		tcp_limiter_set_transport_options,
 		tcp_set_max_connections,
 		tcp_set_max_connections_clean,
 		tcp_getopts_capability,
@@ -1552,6 +1554,56 @@ tcp_limiter_penalty(Config) ->
 	receive {allow, [_Socket5], {close_connections_for, _}} -> ok after 100 -> error(timeout) end,
 	receive {retired, [_]} -> ok after 100 -> error(timeout) end,
 	receive {retired, [_]} -> ok after 100 -> error(timeout) end,
+	ok = ranch:stop_listener(Name).
+
+tcp_limiter_set_transport_options(Config) ->
+	doc("Ensure that limiter can be updated in `set_transport_options/2`."),
+	Name = name(),
+	SockOpts = config(socket_opts, Config),
+	Limiter1 = {counting_limiter, #{
+		every => 2,
+		penalty => close_connection,
+		report_to => self()}},
+	Limiter2 = {counting_limiter, #{
+		every => 1000,
+		penalty => {close_connections_for, 1000},
+		report_to => self()}},
+	{ok, _} = ranch:start_listener(Name,
+		ranch_tcp, #{num_acceptors => 1, limiter => Limiter1, socket_opts => SockOpts},
+		echo_protocol, []),
+	Port = ranch:get_port(Name),
+	ConnectOptions = [binary, {active, false}],
+	Localhost = "localhost",
+	%% Every other connection is disallowed initially:
+	{ok, Socket1} = gen_tcp:connect(Localhost, Port, ConnectOptions),
+	{error, timeout} = gen_tcp:recv(Socket1, 0, 100),
+	{ok, Socket2} = gen_tcp:connect(Localhost, Port, ConnectOptions),
+	{error, closed} = gen_tcp:recv(Socket2, 0, 100),
+	{ok, Socket3} = gen_tcp:connect(Localhost, Port, ConnectOptions),
+	{error, timeout} = gen_tcp:recv(Socket3, 0, 100),
+	{ok, Socket4} = gen_tcp:connect(Localhost, Port, ConnectOptions),
+	{error, closed} = gen_tcp:recv(Socket4, 0, 100),
+	%% Set more lax limiter:
+	ok = ranch:set_transport_options(Name,
+		#{num_acceptors => 1, limiter => Limiter2, socket_opts => SockOpts}),
+	%% Connections are free to ho now:
+	{ok, Socket5} = gen_tcp:connect(Localhost, Port, ConnectOptions),
+	{error, timeout} = gen_tcp:recv(Socket5, 0, 100),
+	{ok, Socket6} = gen_tcp:connect(Localhost, Port, ConnectOptions),
+	{error, timeout} = gen_tcp:recv(Socket6, 0, 100),
+	%% Verify limiter was notified of existing connection after update:
+	receive {allow, [_Socket1], ok} -> ok after 100 -> error(timeout) end,
+	Pid1 = receive {accepted, [P1]} -> P1 after 100 -> error(timeout) end,
+	receive {allow, [_Socket2], close_connection} -> ok after 100 -> error(timeout) end,
+	receive {allow, [_Socket3], ok} -> ok after 100 -> error(timeout) end,
+	Pid2 = receive {accepted, [P2]} -> P2 after 100 -> error(timeout) end,
+	receive {allow, [_Socket4], close_connection} -> ok after 100 -> error(timeout) end,
+	receive {accepted, [Pid1]} -> ok after 100 -> error(timeout) end,
+	receive {accepted, [Pid2]} -> ok after 100 -> error(timeout) end,
+	receive {allow, [_Socket5], ok} -> ok after 100 -> error(timeout) end,
+	receive {accepted, [_Pid3]} -> ok after 100 -> error(timeout) end,
+	receive {allow, [_Socket6], ok} -> ok after 100 -> error(timeout) end,
+	receive {accepted, [_Pid4]} -> ok after 100 -> error(timeout) end,
 	ok = ranch:stop_listener(Name).
 
 tcp_set_max_connections(Config) ->

--- a/test/counting_limiter.erl
+++ b/test/counting_limiter.erl
@@ -1,0 +1,33 @@
+-module(counting_limiter).
+-behaviour(ranch_conns_limiter).
+
+-export([create/1]).
+-export([allow/2]).
+-export([accepted/2, retired/2]).
+
+create(Options) ->
+	Options#{n => 0}.
+
+allow(Socket, State0 = #{n := N0, every := Every, penalty := Penalty}) ->
+	N = N0 + 1,
+	State = State0#{n := N},
+	Ret = case N rem Every of
+		0 -> Penalty;
+		_ -> ok
+	end,
+	report(?FUNCTION_NAME, [Socket], Ret, State),
+	{Ret, State}.
+
+accepted(Pid, State) ->
+	report(?FUNCTION_NAME, [Pid], State),
+	State.
+
+retired(Pid, State) ->
+	report(?FUNCTION_NAME, [Pid], State),
+	State.
+
+report(Function, Args, Ret, #{report_to := Pid}) ->
+	Pid ! {Function, Args, Ret}.
+
+report(Function, Args, #{report_to := Pid}) ->
+	Pid ! {Function, Args}.


### PR DESCRIPTION
A limiter is a piece of state managed by specified module, following simple behaviour defined in `ranch_conns_limiter`. Limiter can impose a _penalty_ on its respective acceptor. To have more predictable results with such setup, it's better to keep `num_acceptors` and `num_conns_sups` equal (which is the current default).

Limiter is managed and owned by connection supervisor, which notifies its respective acceptor about ongoing penalties. This is done for `accepted/2` and `retired/2` callbacks to work reliably, which can be used to hard limit total number of connections w/o blocking the acceptor.

---

Part of [EMQX-14393](https://emqx.atlassian.net/browse/EMQX-14393)